### PR TITLE
REDIS HOST, PORT & DB are configurable env vars

### DIFF
--- a/flanker/addresslib/drivers/redis_driver.py
+++ b/flanker/addresslib/drivers/redis_driver.py
@@ -1,13 +1,18 @@
 import collections
+import os
 import redis
 
 class RedisCache(collections.MutableMapping):
     "RedisCache has the same interface as a dict, but talks to a redis server"
 
-    def __init__(self, host='localhost', port=6379, prefix='mxr:', ttl=604800):
+    def __init__(self, host=None, port=None, prefix='mxr:', ttl=604800):
         self.prefix = prefix
         self.ttl = ttl
-        self.r = redis.StrictRedis(host=host, port=port, db=0)
+
+        host = host or os.environ.get('REDIS_HOST', 'localhost')
+        port = port or os.environ.get('REDIS_PORT', 6379)
+        db = os.environ.get('REDIS_DB', 0)
+        self.r = redis.StrictRedis(host=host, port=port, db=db)
 
     def __getitem__(self, key):
         try:


### PR DESCRIPTION
Make local Redis cache configurable via environment variables REDIS_HOST, REDIS_PORT, and REDIS_DB with the defaults matching the current behavior.

This addresses the issue: https://github.com/mailgun/flanker/issues/92